### PR TITLE
Allow handling features with null geometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arcgis-pbf-parser",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A library for parsing the arcgis pbf format into geojson",
   "main": "dist/arcgis-pbf.cjs",
   "module": "dist/arcgis-pbf.mjs",

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,7 @@ export default function decode(featureCollectionBuffer) {
       type: 'Feature',
       id: getFeatureId(fields, f.attributes, objectIdField),
       properties: collectAttributes(fields, f.attributes),
-      geometry: geometryParser(f, transform)
+      geometry: f.geometry && geometryParser(f, transform)
     })
   }
 


### PR DESCRIPTION
Updated to pass `geometry: null` as-is, instead of passing the value to `geometryParser` which will result the `Cannot read properties of undefined (reading 'length') error`

[Example URL](https://services1.arcgis.com/YZCmUqbcsUpOKfj7/arcgis/rest/services/PGHWebZoning/FeatureServer/0/query?f=pbf&geometry=%7B%22spatialReference%22%3A%7B%22latestWkid%22%3A4326%2C%22wkid%22%3A4326%7D%2C%22xmin%22%3A-79.892578125%2C%22ymin%22%3A40.38002840251182%2C%22xmax%22%3A-79.8046875%2C%22ymax%22%3A40.4469470596005%7D&where=1%3D1&outFields=*&outSR=4326&returnZ=false&returnM=false&precision=8&quantizationParameters=%7B%22extent%22%3A%7B%22spatialReference%22%3A%7B%22latestWkid%22%3A4326%2C%22wkid%22%3A4326%7D%2C%22xmin%22%3A-79.892578125%2C%22ymin%22%3A40.38002840251182%2C%22xmax%22%3A-79.8046875%2C%22ymax%22%3A40.4469470596005%7D%2C%22tolerance%22%3A0.000025749206542959253%2C%22mode%22%3A%22view%22%7D&resultType=tile&spatialRel=esriSpatialRelIntersects&geometryType=esriGeometryEnvelope&inSR=4326)

Expect the URL to be successfully parsed without crashing the parser